### PR TITLE
Set correct client_addr when using reverse proxy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ The ``pyramid_heroku.herokuapp_access`` tween depends on
 ``pyramid_heroku.client_addr`` tween and it requires you to list whitelisted IPs
 in the ``pyramid_heroku.herokuapp_whitelist`` setting.
 
+The ``pyramid_heroku.client_addr`` tween sets request.client_addr to an IP we
+can trust. It handles IP spoofing via ``X-Forwarded-For`` headers and
+ignores Cloudflare's IPs when using Cloudflare reverse proxy.
+
 
 Usage example for automatic alembic migration script::
 

--- a/pyramid_heroku/tests/test_client_addr.py
+++ b/pyramid_heroku/tests/test_client_addr.py
@@ -2,20 +2,47 @@
 
 from pyramid import request
 from pyramid import testing
+from zope.testing.loggingsupport import InstalledHandler
 
+import logging
 import mock
+import responses
+import structlog
 import unittest
+
+tweens_handler = InstalledHandler("pyramid_heroku.client_addr")
 
 
 class TestClientAddrTween(unittest.TestCase):
+    def wrap_logger(self, _, __, event_dict):
+        """Have structlog output to the standard logger, so that tweens_handler can intercept its messages."""
+        wrapped_logger = logging.getLogger("pyramid_heroku.client_addr")
+        wrapped_logger.info(event_dict["event"])
+        return event_dict["event"]
+
     def setUp(self):
+        tweens_handler.clear()
         self.config = testing.setUp()
         self.request = request.Request({})
 
         self.handler = mock.Mock()
         self.registry = None
 
+        self.responses = responses.RequestsMock()
+        self.responses.start()
+        self.responses.add(
+            responses.GET,
+            "https://www.cloudflare.com/ips-v4",  # noqa
+            status=200,
+            body="8.8.8.0/24\n9.9.9.0/24",
+        )
+
+        structlog.configure(processors=[self.wrap_logger], context_class=dict)
+
     def tearDown(self):
+        self.responses.stop()
+        self.responses.reset()
+        tweens_handler.clear()
         testing.tearDown()
 
     def test_direct_access(self):
@@ -45,3 +72,58 @@ class TestClientAddrTween(unittest.TestCase):
         ClientAddr(self.handler, self.registry)(self.request)
         self.handler.assert_called_with(self.request)
         self.assertEqual(self.request.client_addr, "1.2.3.4")
+
+    def test_cloudflare_ip_ignored(self):
+        from pyramid_heroku.client_addr import ClientAddr
+
+        self.request.environ["REMOTE_ADDR"] = "127.0.0.1"  # load balancer
+        self.request.headers["X-Forwarded-For"] = " 6.6.6.6, 1.2.3.4, 9.9.9.9"
+
+        ClientAddr(self.handler, self.registry)(self.request)
+        self.handler.assert_called_with(self.request)
+        self.assertEqual(self.request.client_addr, "1.2.3.4")
+
+    def test_cloudflare_ip_list_get_error(self):
+        from pyramid_heroku.client_addr import ClientAddr
+
+        self.responses.reset()
+        self.responses.add(
+            responses.GET,
+            "https://www.cloudflare.com/ips-v4",  # noqa
+            status=501,
+            body="error",
+        )
+
+        self.request.environ["REMOTE_ADDR"] = "127.0.0.1"  # load balancer
+        self.request.headers["X-Forwarded-For"] = " 6.6.6.6, 1.2.3.4, 9.9.9.9"
+
+        registry = mock.Mock()
+        registry.settings = {}
+        ClientAddr(self.handler, registry)(self.request)
+        self.handler.assert_called_with(self.request)
+        self.assertEqual(self.request.client_addr, "9.9.9.9")
+
+        self.assertEqual(len(tweens_handler.records), 1)
+        self.assertEqual(
+            "Failed getting a list of Cloudflare IPs", tweens_handler.records[0].msg
+        )
+
+        # structlog logging
+        tweens_handler.clear()
+        self.responses.reset()
+        self.responses.add(
+            responses.GET,
+            "https://www.cloudflare.com/ips-v4",  # noqa
+            status=501,
+            body="error",
+        )
+
+        registry.settings = {"pyramid_heroku.structlog": True}
+        ClientAddr(self.handler, registry)(self.request)
+        self.handler.assert_called_with(self.request)
+        self.assertEqual(self.request.client_addr, "9.9.9.9")
+
+        self.assertEqual(len(tweens_handler.records), 1)
+        self.assertEqual(
+            "Failed getting a list of Cloudflare IPs", tweens_handler.records[0].msg
+        )


### PR DESCRIPTION
When app is behind a reverse proxy the last IP in `X-Forwarded-For` is the IP of the proxy server.

Second to last IP is the IP of the client.

IPs before the client and proxy IP are set by the client using `X-Forwarded-For` header.

Set `pyramid_heroku.reverse_proxy = true` to use the second to last IP for `client_addr`.