### PR TITLE
Handle IPv6 in client_addr tween

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@
 Changes
 =======
 
+0.9.2
+-----
+
+ * Handle IPv6 in client_addr tween. ClientAddr tween was crashing when getting
+   IPv6 addresses. Use IP version agnostic parsing. Fetch the list of
+   CloudFlare's IPv6 IPs.
+   [am-on]
+
+
 0.9.1
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyramid_heroku"
-version = "0.9.1"
+version = "0.9.2"
 description = "A bunch of helpers for successfully running Pyramid on Heroku."
 readme = "README.rst"
 include = [ "CHANGES.rst", "COPYING.txt" ]

--- a/pyramid_heroku/tests/test_client_addr.py
+++ b/pyramid_heroku/tests/test_client_addr.py
@@ -26,15 +26,22 @@ class TestClientAddrTween(unittest.TestCase):
         self.request = request.Request({})
 
         self.handler = mock.Mock()
-        self.registry = None
+        self.registry = mock.Mock()
+        self.registry.settings = {}
 
         self.responses = responses.RequestsMock()
         self.responses.start()
         self.responses.add(
             responses.GET,
-            "https://www.cloudflare.com/ips-v4",  # noqa
+            "https://www.cloudflare.com/ips-v4",
             status=200,
             body="8.8.8.0/24\n9.9.9.0/24",
+        )
+        self.responses.add(
+            responses.GET,
+            "https://www.cloudflare.com/ips-v6",
+            status=200,
+            body="2400:cb00::/32\n2606:4700::/32",
         )
 
         structlog.configure(processors=[self.wrap_logger], context_class=dict)
@@ -77,7 +84,45 @@ class TestClientAddrTween(unittest.TestCase):
         from pyramid_heroku.client_addr import ClientAddr
 
         self.request.environ["REMOTE_ADDR"] = "127.0.0.1"  # load balancer
-        self.request.headers["X-Forwarded-For"] = " 6.6.6.6, 1.2.3.4, 9.9.9.9"
+        self.request.headers["X-Forwarded-For"] = "6.6.6.6, 1.2.3.4, 9.9.9.9"
+
+        ClientAddr(self.handler, self.registry)(self.request)
+        self.handler.assert_called_with(self.request)
+        self.assertEqual(self.request.client_addr, "1.2.3.4")
+
+    def test_cloudflare_ipv6_ignored(self):
+        from pyramid_heroku.client_addr import ClientAddr
+
+        self.request.environ["REMOTE_ADDR"] = "127.0.0.1"  # load balancer
+        self.request.headers["X-Forwarded-For"] = (
+            "2600:cb00:0000:0000:0000:0000:0000:0001, "
+            "2500:cb00:0000:0000:0000:0000:0000:0001, "
+            "2400:cb00:0000:0000:0000:0000:0000:0001"
+        )
+
+        ClientAddr(self.handler, self.registry)(self.request)
+        self.handler.assert_called_with(self.request)
+        self.assertEqual(
+            self.request.client_addr, "2500:cb00:0000:0000:0000:0000:0000:0001"
+        )
+
+    def test_invalid_ips(self):
+        from pyramid_heroku.client_addr import ClientAddr
+
+        self.request.environ["REMOTE_ADDR"] = "127.0.0.1"  # load balancer
+        self.request.headers["X-Forwarded-For"] = "1.2.3.4, invalid_ip not_ip"
+
+        ClientAddr(self.handler, self.registry)(self.request)
+        self.handler.assert_called_with(self.request)
+        self.assertEqual(self.request.client_addr, "1.2.3.4")
+
+    def test_cloudflare_ipv4_6_ignored(self):
+        from pyramid_heroku.client_addr import ClientAddr
+
+        self.request.environ["REMOTE_ADDR"] = "127.0.0.1"  # load balancer
+        self.request.headers[
+            "X-Forwarded-For"
+        ] = "1.2.3.4, 9.9.9.9, 2400:cb00:0000:0000:0000:0000:0000:0001"
 
         ClientAddr(self.handler, self.registry)(self.request)
         self.handler.assert_called_with(self.request)
@@ -88,10 +133,10 @@ class TestClientAddrTween(unittest.TestCase):
 
         self.responses.reset()
         self.responses.add(
-            responses.GET,
-            "https://www.cloudflare.com/ips-v4",  # noqa
-            status=501,
-            body="error",
+            responses.GET, "https://www.cloudflare.com/ips-v4", status=501, body="error"
+        )
+        self.responses.add(
+            responses.GET, "https://www.cloudflare.com/ips-v6", status=501, body="error"
         )
 
         self.request.environ["REMOTE_ADDR"] = "127.0.0.1"  # load balancer
@@ -103,9 +148,14 @@ class TestClientAddrTween(unittest.TestCase):
         self.handler.assert_called_with(self.request)
         self.assertEqual(self.request.client_addr, "9.9.9.9")
 
-        self.assertEqual(len(tweens_handler.records), 1)
+        self.assertEqual(len(tweens_handler.records), 2)
         self.assertEqual(
-            "Failed getting a list of Cloudflare IPs", tweens_handler.records[0].msg
+            "Failed getting a list of IPs from https://www.cloudflare.com/ips-v4",
+            tweens_handler.records[0].msg,
+        )
+        self.assertEqual(
+            "Failed getting a list of IPs from https://www.cloudflare.com/ips-v6",
+            tweens_handler.records[1].msg,
         )
 
         # structlog logging
@@ -117,13 +167,21 @@ class TestClientAddrTween(unittest.TestCase):
             status=501,
             body="error",
         )
+        self.responses.add(
+            responses.GET, "https://www.cloudflare.com/ips-v6", status=501, body="error"
+        )
 
         registry.settings = {"pyramid_heroku.structlog": True}
         ClientAddr(self.handler, registry)(self.request)
         self.handler.assert_called_with(self.request)
         self.assertEqual(self.request.client_addr, "9.9.9.9")
 
-        self.assertEqual(len(tweens_handler.records), 1)
+        self.assertEqual(len(tweens_handler.records), 2)
         self.assertEqual(
-            "Failed getting a list of Cloudflare IPs", tweens_handler.records[0].msg
+            "Failed getting a list of IPs from https://www.cloudflare.com/ips-v4",
+            tweens_handler.records[0].msg,
+        )
+        self.assertEqual(
+            "Failed getting a list of IPs from https://www.cloudflare.com/ips-v6",
+            tweens_handler.records[1].msg,
         )


### PR DESCRIPTION
ClientAddr tween was crashing when getting IPv6 addresses.

- Use IP version agnostic parsing.
- Fetch the list of CloudFlare's IPv6 IPs.