### PR TITLE
Configure pytest for better BlueRacer report

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --doctest-modules
+junit_duration_report = call


### PR DESCRIPTION
For test times, track only call durations.  

Ref: https://blueracer.io/docs/runner/pytest#better-results